### PR TITLE
Cleanup message queue after sending them through the socket

### DIFF
--- a/src/ClientImplementation.js
+++ b/src/ClientImplementation.js
@@ -412,13 +412,16 @@ class ClientImplementation {
   _process_queue() {
     // Process messages in order they were added
     // Send all queued messages down socket connection
-
     const socket = this.socket;
-    this._messagesAwaitingDispatch.reverse().forEach(wireMessage => {
+
+    const fifo = this._messagesAwaitingDispatch.reverse();
+
+    let wireMessage;
+    while ((wireMessage = fifo.pop())) {
       this._trace('Client._socketSend', wireMessage);
       socket && socket.send(wireMessage.encode());
       wireMessage.onDispatched && wireMessage.onDispatched();
-    });
+    }
 
     this.sendPinger && this.sendPinger.reset();
   }

--- a/src/ClientImplementation.js
+++ b/src/ClientImplementation.js
@@ -414,10 +414,9 @@ class ClientImplementation {
     // Send all queued messages down socket connection
     const socket = this.socket;
 
-    const fifo = this._messagesAwaitingDispatch.reverse();
-
+    // Consume each message and remove it from the queue
     let wireMessage;
-    while ((wireMessage = fifo.pop())) {
+    while ((wireMessage = this._messagesAwaitingDispatch.shift())) {
       this._trace('Client._socketSend', wireMessage);
       socket && socket.send(wireMessage.encode());
       wireMessage.onDispatched && wireMessage.onDispatched();


### PR DESCRIPTION
Hi There! This fixes an issue that I detected that messages sent to a particular topic one, where always sent every time you attempted to send another message to that topic, digging through the code and comparing it to the original paho, I found out that the `process_queue` was not cleaning the queue after sending the messages