### PR TITLE
Fixed issue where the pinger would attempt to ping while the socket is closing

### DIFF
--- a/src/ClientImplementation.js
+++ b/src/ClientImplementation.js
@@ -152,6 +152,8 @@ class ClientImplementation {
 
       this.socket && (this.socket.onopen = () => null);
       this.socket && (this.socket.send(wireMessage.encode()));
+
+      this.sendPinger && this.sendPinger.reset();
     };
 
     this.socket.onmessage = (event) => {
@@ -418,8 +420,6 @@ class ClientImplementation {
       socket && socket.send(wireMessage.encode());
       wireMessage.onDispatched && wireMessage.onDispatched();
     }
-
-    this.sendPinger && this.sendPinger.reset();
   }
 
   /**

--- a/src/Pinger.js
+++ b/src/Pinger.js
@@ -17,7 +17,6 @@ export default class {
   constructor(client: ClientImplementation, keepAliveIntervalSeconds: number) {
     this._client = client;
     this._keepAliveIntervalMs = keepAliveIntervalSeconds * 1000;
-    this.reset();
   }
 
   _doPing() {


### PR DESCRIPTION
This was causing a crash in my application. The call to reset the pinger object was occurring while the app was trying to disconnect the socket, which was causing pings to sometimes occur while the socket was closed. This was also an issue when the socket was opening. I fixed the issue by only resetting the pinger when the socket opens.