### PR TITLE
Moved ping reset before wireMessage.onDispatched() 

### DIFF
--- a/src/ClientImplementation.js
+++ b/src/ClientImplementation.js
@@ -411,6 +411,8 @@ class ClientImplementation {
     // Send all queued messages down socket connection
     const socket = this.socket;
 
+    this.sendPinger && this.sendPinger.reset();
+
     // Consume each message and remove it from the queue
     let wireMessage;
     while ((wireMessage = this._messagesAwaitingDispatch.shift())) {
@@ -418,8 +420,6 @@ class ClientImplementation {
       socket && socket.send(wireMessage.encode());
       wireMessage.onDispatched && wireMessage.onDispatched();
     }
-
-    this.sendPinger && this.sendPinger.reset();
   }
 
   /**


### PR DESCRIPTION
Note, this PR is related to "Fixed issue where the pinger would attempt to ping while the socket is closing" https://github.com/rh389/react-native-paho-mqtt/pull/9

This PR fixes a crash when resuming an app that disconnected the mqtt client before going to the background:

```
E AndroidRuntime: Process: be.tadaam.edp, PID: 4237
E AndroidRuntime: com.facebook.react.common.JavascriptException: Error: INVALID_STATE_ERR, js engine: hermes, stack:
E AndroidRuntime: send@1:208833
E AndroidRuntime: _doPing@1:1059789
```

The issue happens when the app goes to background, and the mqtt client is disconnected. In that case ClientImplementation.disconnect() sends a last MESSAGE_TYPE.DISCONNECT message, which on wireMessage.onDispatched() does a ClientImplementation._disconnected() call. In _disconnected(), sendPinger.cancel() is executed, effectively disabling keepalives.

However, _process_queue() always sends a sendPinger.reset() after dispatching messages to reset the keepAlive mechanism. So a new keepAlive is scheduled after the app goes to background and the client is disconnected.

If the client comes back to foreground, the sendPinger._doPing() will immediately execute on a disconnected client as it was scheduled before going to the background, and is still waiting on the JS message queue. The result is a crash.

The solution is to reset the pinger's keepAlive mechanism before processing the message queue. In that case the keepAlive is still pushed ahead in time on every message that is sent, and the mechanism is not reset after disconnecting.


